### PR TITLE
Repositories and Coverage

### DIFF
--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,14 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
+connection.project.dir=
+eclipse.preferences.version=1
+gradle.user.home=
+# NOTE: You will need to override this to fit your system.
+java.home=/usr/lib/jvm/java-11-openjdk-amd64
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,9 @@
-eclipse.preferences.version=1
+#
+#Mon Feb 28 15:09:16 PST 2022
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
-org.eclipse.jdt.core.compiler.compliance=11
-org.eclipse.jdt.core.compiler.problem.unusedWarningToken=ignore
 org.eclipse.jdt.core.compiler.source=11
+org.eclipse.jdt.core.compiler.problem.unusedWarningToken=ignore
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.compliance=11

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,13 +1,13 @@
 {
     "recommendations": [
         "gabrielbb.vscode-lombok",
-        "markis.code-coverage",
         "vscjava.vscode-java-pack",
         "eamodio.gitlens",
         "vscjava.vscode-gradle",
         "ms-vsliveshare.vsliveshare-pack",
         "jebbs.plantuml",
         "madhavd1.javadoc-tools",
-        "GitHub.vscode-pull-request-github"
+        "github.vscode-pull-request-github",
+        "ryanluker.vscode-coverage-gutters"
     ]
 }

--- a/build.gradle
+++ b/build.gradle
@@ -68,10 +68,31 @@ application {
     mainClassName = 'edu.northeastern.cs5500.starterbot.App'
 }
 
+// Enable jacoco coverage
+apply plugin: 'jacoco'
+
 test {
     // Use junit platform for unit tests
     useJUnitPlatform()
+
+    // Create a Jacoco report after each test run
+    finalizedBy jacocoTestReport
 }
+
+// Generate an XML report that the coverage extension can use
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.enabled true
+        // Change html.enabled to true if you want html reports
+        html.enabled false
+        csv.enabled false
+        xml.destination file("${buildDir}/reports/jacoco.xml")
+    }
+}
+
+// Check coverage after each test run
+check.dependsOn jacocoTestCoverageVerification
 
 // Target Java 11 - make sure system.properties matches this as well
 sourceCompatibility = 1.11

--- a/src/main/java/edu/northeastern/cs5500/starterbot/command/CommandModule.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/command/CommandModule.java
@@ -12,4 +12,10 @@ public class CommandModule {
     public Command provideSayCommand(SayCommand sayCommand) {
         return sayCommand;
     }
+
+    @Provides
+    @IntoSet
+    public Command providePreferredNameCommand(PreferredNameCommand preferredNameCommand) {
+        return preferredNameCommand;
+    }
 }

--- a/src/main/java/edu/northeastern/cs5500/starterbot/command/PreferredNameCommand.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/command/PreferredNameCommand.java
@@ -38,7 +38,7 @@ public class PreferredNameCommand implements Command {
     public void onEvent(CommandInteraction event) {
         log.info("event: /preferredname");
         String preferredName = event.getOption("name").getAsString();
-        
+
         String discordUserId = event.getUser().getId();
 
         String oldPreferredName = userPreferenceController.getPreferredNameForUser(discordUserId);

--- a/src/main/java/edu/northeastern/cs5500/starterbot/command/PreferredNameCommand.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/command/PreferredNameCommand.java
@@ -1,0 +1,59 @@
+package edu.northeastern.cs5500.starterbot.command;
+
+import edu.northeastern.cs5500.starterbot.controller.UserPreferenceController;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.interactions.commands.CommandInteraction;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.CommandData;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+
+@Singleton
+@Slf4j
+public class PreferredNameCommand implements Command {
+
+    @Inject UserPreferenceController userPreferenceController;
+
+    @Inject
+    public PreferredNameCommand() {}
+
+    @Override
+    public String getName() {
+        return "preferredname";
+    }
+
+    @Override
+    public CommandData getCommandData() {
+        return new CommandData(getName(), "Tell the bot what name to address you with")
+                .addOptions(
+                        new OptionData(
+                                        OptionType.STRING,
+                                        "name",
+                                        "The bot will use this name to talk to you going forward")
+                                .setRequired(true));
+    }
+
+    @Override
+    public void onEvent(CommandInteraction event) {
+        log.info("event: /preferredname");
+        String preferredName = event.getOption("name").getAsString();
+        
+        String discordUserId = event.getUser().getId();
+
+        String oldPreferredName = userPreferenceController.getPreferredNameForUser(discordUserId);
+
+        userPreferenceController.setPreferredNameForUser(discordUserId, preferredName);
+
+        if (oldPreferredName == null) {
+            event.reply("Your preferred name has been set to " + preferredName).queue();
+        } else {
+            event.reply(
+                            "Your preferred name has been changed from "
+                                    + oldPreferredName
+                                    + " to "
+                                    + preferredName)
+                    .queue();
+        }
+    }
+}

--- a/src/main/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceController.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceController.java
@@ -9,16 +9,25 @@ import javax.inject.Inject;
 
 public class UserPreferenceController {
 
-    @Inject GenericRepository<UserPreference> userPreferenceRepository;
+    GenericRepository<UserPreference> userPreferenceRepository;
 
     @Inject
-    UserPreferenceController() {}
+    UserPreferenceController(GenericRepository<UserPreference> userPreferenceRepository) {
+        this.userPreferenceRepository = userPreferenceRepository;
+
+        if (userPreferenceRepository.count() == 0) {
+            UserPreference userPreference = new UserPreference();
+            userPreference.setDiscordUserId("1234");
+            userPreference.setPreferredName("Alex");
+            userPreferenceRepository.add(userPreference);
+        }
+    }
 
     public void setPreferredNameForUser(String discordMemberId, String preferredName) {
         UserPreference userPreference = getUserPreferenceForMemberId(discordMemberId);
 
         userPreference.setPreferredName(preferredName);
-        userPreferenceRepository.add(userPreference);
+        userPreferenceRepository.update(userPreference);
     }
 
     @Nullable
@@ -37,6 +46,7 @@ public class UserPreferenceController {
 
         UserPreference userPreference = new UserPreference();
         userPreference.setDiscordUserId(discordMemberId);
+        userPreferenceRepository.add(userPreference);
         return userPreference;
     }
 }

--- a/src/main/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceController.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceController.java
@@ -1,0 +1,42 @@
+package edu.northeastern.cs5500.starterbot.controller;
+
+import com.mongodb.lang.Nullable;
+import edu.northeastern.cs5500.starterbot.model.UserPreference;
+import edu.northeastern.cs5500.starterbot.repository.GenericRepository;
+import java.util.Collection;
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+
+public class UserPreferenceController {
+
+    @Inject GenericRepository<UserPreference> userPreferenceRepository;
+
+    @Inject
+    UserPreferenceController() {}
+
+    public void setPreferredNameForUser(String discordMemberId, String preferredName) {
+        UserPreference userPreference = getUserPreferenceForMemberId(discordMemberId);
+
+        userPreference.setPreferredName(preferredName);
+        userPreferenceRepository.add(userPreference);
+    }
+
+    @Nullable
+    public String getPreferredNameForUser(String discordMemberId) {
+        return getUserPreferenceForMemberId(discordMemberId).getPreferredName();
+    }
+
+    @Nonnull
+    public UserPreference getUserPreferenceForMemberId(String discordMemberId) {
+        Collection<UserPreference> userPreferences = userPreferenceRepository.getAll();
+        for (UserPreference currentUserPreference : userPreferences) {
+            if (currentUserPreference.getDiscordUserId().equals(discordMemberId)) {
+                return currentUserPreference;
+            }
+        }
+
+        UserPreference userPreference = new UserPreference();
+        userPreference.setDiscordUserId(discordMemberId);
+        return userPreference;
+    }
+}

--- a/src/main/java/edu/northeastern/cs5500/starterbot/model/UserPreference.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/model/UserPreference.java
@@ -1,0 +1,16 @@
+package edu.northeastern.cs5500.starterbot.model;
+
+import lombok.Data;
+import org.bson.types.ObjectId;
+
+@Data
+public class UserPreference implements Model {
+    ObjectId id;
+
+    // This is the "snowflake id" of the user
+    // e.g. event.getUser().getId()
+    String discordUserId;
+
+    // The user wants to be referred to by this name
+    String preferredName;
+}

--- a/src/main/java/edu/northeastern/cs5500/starterbot/repository/InMemoryRepository.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/repository/InMemoryRepository.java
@@ -5,8 +5,10 @@ import java.util.Collection;
 import java.util.HashMap;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.bson.types.ObjectId;
 
+@Singleton
 public class InMemoryRepository<T extends Model> implements GenericRepository<T> {
 
     HashMap<ObjectId, T> collection;

--- a/src/main/java/edu/northeastern/cs5500/starterbot/repository/RepositoryModule.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/repository/RepositoryModule.java
@@ -1,6 +1,14 @@
 package edu.northeastern.cs5500.starterbot.repository;
 
 import dagger.Module;
+import dagger.Provides;
+import edu.northeastern.cs5500.starterbot.model.UserPreference;
 
 @Module
-public class RepositoryModule {}
+public class RepositoryModule {
+    @Provides
+    public GenericRepository<UserPreference> provideUserPreferencesRepository(
+            InMemoryRepository<UserPreference> repository) {
+        return repository;
+    }
+}

--- a/src/main/java/edu/northeastern/cs5500/starterbot/repository/RepositoryModule.java
+++ b/src/main/java/edu/northeastern/cs5500/starterbot/repository/RepositoryModule.java
@@ -6,9 +6,22 @@ import edu.northeastern.cs5500.starterbot.model.UserPreference;
 
 @Module
 public class RepositoryModule {
+    // NOTE: You can use the following lines if you'd like to store objects in memory.
+    // NOTE: The presence of commented-out code in your project *will* result in a lowered grade.
+    // @Provides
+    // public GenericRepository<UserPreference> provideUserPreferencesRepository(
+    //         InMemoryRepository<UserPreference> repository) {
+    //     return repository;
+    // }
+
     @Provides
     public GenericRepository<UserPreference> provideUserPreferencesRepository(
-            InMemoryRepository<UserPreference> repository) {
+            MongoDBRepository<UserPreference> repository) {
         return repository;
+    }
+
+    @Provides
+    public Class<UserPreference> provideUserPreference() {
+        return UserPreference.class;
     }
 }

--- a/src/test/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceControllerTest.java
+++ b/src/test/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceControllerTest.java
@@ -1,0 +1,62 @@
+package edu.northeastern.cs5500.starterbot.controller;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import edu.northeastern.cs5500.starterbot.repository.InMemoryRepository;
+import org.junit.jupiter.api.Test;
+
+class UserPreferenceControllerTest {
+    // TODO: replace with discord IDs that are more real
+    static final String USER_ID_1 = "23h5ikoqaehokljhaoe";
+    static final String USER_ID_2 = "2kjfksdjdkhokljhaoe";
+    static final String PREFERRED_NAME_1 = "Joe";
+    static final String PREFERRED_NAME_2 = "Penny";
+
+    private UserPreferenceController getUserPreferenceController() {
+        UserPreferenceController userPreferenceController = new UserPreferenceController();
+        userPreferenceController.userPreferenceRepository = new InMemoryRepository<>();
+        return userPreferenceController;
+    }
+
+    @Test
+    void testSetNameActuallySetsName() {
+        // setup
+        UserPreferenceController userPreferenceController = getUserPreferenceController();
+
+        // precondition
+        assertThat(userPreferenceController.getPreferredNameForUser(USER_ID_1))
+                .isNotEqualTo(PREFERRED_NAME_1);
+
+        // mutation
+        userPreferenceController.setPreferredNameForUser(USER_ID_1, PREFERRED_NAME_1);
+
+        // postcondition
+        assertThat(userPreferenceController.getPreferredNameForUser(USER_ID_1))
+                .isEqualTo(PREFERRED_NAME_1);
+    }
+
+    @Test
+    void testSetNameOverwritesOldName() {
+        UserPreferenceController userPreferenceController = getUserPreferenceController();
+        userPreferenceController.setPreferredNameForUser(USER_ID_1, PREFERRED_NAME_1);
+        assertThat(userPreferenceController.getPreferredNameForUser(USER_ID_1))
+                .isEqualTo(PREFERRED_NAME_1);
+
+        userPreferenceController.setPreferredNameForUser(USER_ID_1, PREFERRED_NAME_2);
+        assertThat(userPreferenceController.getPreferredNameForUser(USER_ID_1))
+                .isEqualTo(PREFERRED_NAME_2);
+    }
+
+    @Test
+    void testSetNameOnlyOverwritesTargetUser() {
+        UserPreferenceController userPreferenceController = getUserPreferenceController();
+
+        userPreferenceController.setPreferredNameForUser(USER_ID_1, PREFERRED_NAME_1);
+        userPreferenceController.setPreferredNameForUser(USER_ID_2, PREFERRED_NAME_2);
+
+        assertThat(userPreferenceController.getPreferredNameForUser(USER_ID_1))
+                .isEqualTo(PREFERRED_NAME_1);
+        assertThat(userPreferenceController.getPreferredNameForUser(USER_ID_2))
+                .isEqualTo(PREFERRED_NAME_2);
+    }
+}

--- a/src/test/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceControllerTest.java
+++ b/src/test/java/edu/northeastern/cs5500/starterbot/controller/UserPreferenceControllerTest.java
@@ -13,8 +13,8 @@ class UserPreferenceControllerTest {
     static final String PREFERRED_NAME_2 = "Penny";
 
     private UserPreferenceController getUserPreferenceController() {
-        UserPreferenceController userPreferenceController = new UserPreferenceController();
-        userPreferenceController.userPreferenceRepository = new InMemoryRepository<>();
+        UserPreferenceController userPreferenceController =
+                new UserPreferenceController(new InMemoryRepository<>());
         return userPreferenceController;
     }
 


### PR DESCRIPTION
Several different things happening here.

 1. Implementing a basic user preference object and showing how to associate it with a specific Discord user.
 2. Injecting a repository into a controller and the controller into a new command.
 3. A fix for ".settings/org.eclipse.buildship.core.prefs" not found - but you'll need to edit `java.home` appropriately. Note that this file is gitignored so changes to it shouldn't spread to other teammates...
 4. Code coverage! Looks like the previous suggested plugin won't work with Jacoco (at least, I can't remember how I got it to work) so the recommended extension has changed. Note that you'll have to run the `>Coverage Gutters: Watch` command in the VS Code Command palette for this to work - if you do that, you'll see red/yellow/green indicators on the left side of your editor indicating whether lines are not/partially/completely covered.